### PR TITLE
Fix readme links and text

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ Runs PGRCGLOB-WB global hydrology forecast using Cylc and CWL.
 
 ### Cylc
 
-Require version 7.6.x or higher of [Cylc](https://cylc.github.io).
-Follow [installation instructions](https://cylc.github.io/cylc/html/multi/cug-html.html) or run the [Ansible playbook](https://github.com/eWaterCycle/infra/tree/master/eoscpilot)
+Require version 7.6.x or higher of [Cylc](https://cylc.github.io/cylc/).
+Follow [installation instructions](http://cylc.github.io/cylc/doc/built-sphinx/index.html) or run the [Ansible playbook](https://github.com/eWaterCycle/infra/tree/master/eoscpilot)
 
 ### cwl-runner
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ pip2 install cwlref-runner
 Most tasks run inside in a Docker container by the cwl-runner. Follow [installation instructions](https://docs.docker.com/install/) so `docker` can be run as the user.
 
 ## Building docker images
-Docker images of the forecast steps are available on docker hub. Building the docker images itself requires the use of [boatswain](https://https://github.com/NLeSC/boatswain).
+Docker images of the forecast steps are available on docker hub. Building the docker images itself requires the use of [boatswain](https://github.com/NLeSC/boatswain).
 ```bash
 pip install boatswain
 boatswain build

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ pip2 install cwlref-runner
 
 ### Docker
 
-Most tasks run inside in a Docker container by the cwl-runner. Follow [installation instructions](https://docs.docker.com/install/) so `docker` can be run as the user.
+Most tasks run inside a Docker container by the cwl-runner. Follow [installation instructions](https://docs.docker.com/install/) so `docker` can be run as the user.
 
 ## Building docker images
 Docker images of the forecast steps are available on docker hub. Building the docker images itself requires the use of [boatswain](https://github.com/NLeSC/boatswain).
@@ -41,7 +41,7 @@ The forecast consists of multiple steps. In order to get the forecast running, t
 
 Copy `settings.rc.example` to `settings.rc` and edit it.
 
-The initial state tarballs (*.tar.bz2) have to available on the host.
+The initial state tarballs (*.tar.bz2) have to be available on the host.
 The forecast archive root directory should exist on the host.
 
 ## Run


### PR DESCRIPTION
Hi,

Cylc homepage needs the `/cylc/` suffix, and the docs have been recently re-published under another address (not sure if definitive).

Boatswain link had an extra `http//` prefix.

This pull request addresses the issues above.

Thanks for the great work, and for sharing it!!!

Bruno